### PR TITLE
Implement password reset

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,24 @@
+name: PHP Lint
+
+on:
+  push:
+    branches:
+    - master
+    - release/*
+  pull_request:
+    branches:
+    - master
+    - release/*
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: PHP Lint
+      run: |
+        pwd
+        git submodule update --init --recursive
+        php ./lint.php

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,5 +20,6 @@ jobs:
     - name: PHP Lint
       run: |
         pwd
+        if [ -f composer.lock ]; then composer install; fi
         git submodule update --init --recursive
         php ./lint.php

--- a/classes/shgysk8zer0/abstracts/schema.php
+++ b/classes/shgysk8zer0/abstracts/schema.php
@@ -41,7 +41,7 @@ abstract class Schema
 		}
 	}
 
-	final public function __unset(string $key): bool
+	final public function __unset(string $key): void
 	{
 		$method = sprintf('set%s', ucfirst($key));
 

--- a/classes/shgysk8zer0/email.php
+++ b/classes/shgysk8zer0/email.php
@@ -1,0 +1,144 @@
+<?php
+namespace shgysk8zer0;
+
+use \shgysk8zer0\{EmailCredentials, Person};
+use \InvalidArguimentException;
+use \StdClass;
+use PHPMailer\PHPMailer\{PHPMailer, SMTP, Exception as MailException};
+
+final class Email
+{
+	private $_creds = null;
+
+	private $_subject = null;
+
+	private $_body = null;
+
+	private $_alt_body = null;
+
+	private $_recipients = [];
+
+	private $_reply_to = null;
+
+	private $_cc = [];
+
+	private $_bcc = [];
+
+	private $_from = null;
+
+	private $_is_html = true;
+
+	private $_attachments = [];
+
+	final public function __construct(EmailCredentials $creds)
+	{
+		if ($creds->valid()) {
+			$this->_creds = $creds;
+		} else {
+			throw new InvalidArgumentException('Invalid email credentials given');
+		}
+	}
+
+	final public function addAttachment(string $path, ?string $name = null): bool
+	{
+		if (@file_exists($path)) {
+			$attachment = new StdClass();
+			$attachment->path = $path;
+			$attachment->name = $name;
+			$this->_attachments[] = $attachment;
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	final public function addBCC(Person... $people): void
+	{
+		$this->_bcc = array_merge($this->_bcc, $people);
+	}
+
+	final public function addCC(Person... $people): void
+	{
+		$this->_cc = array_merge($this->_cc, $people);
+	}
+
+	final public function addRecipients(Person... $people): void
+	{
+		$this->_recipients = array_merge($this->_recipients, $people);
+	}
+
+	final public function isHTML(bool $val): void
+	{
+		$this->_is_html = $val;
+	}
+
+	final public function setBody(string $val): void
+	{
+		$this->_body = $val;
+	}
+
+	final public function setAltBody(string $val): void
+	{
+		$this->_alt_body = null;
+	}
+
+	final public function setReplyTo(Person $val): void
+	{
+		$this->_reply_to = $val;
+	}
+
+	final public function setSubject(string $val): void
+	{
+		$this->_subject = $val;
+	}
+
+	final public function send(): bool
+	{
+		$mail = new PHPMailer(true);
+
+		if ($this->_creds->valid() and $this->_creds->loginToMailer($mail)) {
+			try {
+				if (isset($this->_from)) {
+					$mail->setFrom($this->_from->getEmail(), $this->_from->getName());
+				} else {
+					$mail->setFrom($this->_creds->getUsername(), $this->_creds->getName());
+				}
+
+				foreach ($this->_recipients as $person) {
+					$mail->addAddress($person->getEmail(), $person->getName());
+				}
+
+				foreach ($this->_cc as $person) {
+					$mail->addCC($person->getEmail(), $person->getName());
+				}
+
+				foreach ($this->_bcc as $person) {
+					$mail->addBCC($person->getEmail(), $person->getName());
+				}
+
+				foreach ($this->_attachments as $attachment) {
+					if (isset($attachment->name)) {
+						$mail->addAttachment($attachment->path, $attachment->name);
+					} else {
+						$mail->addAttachment($attachment->path);
+					}
+				}
+				$mail->isHTML($this->_is_html);
+				$mail->Subject = $this->_subject;
+				$mail->Body    = $this->_body;
+				$mail->send();
+				return true;
+			} catch (MailException $e) {
+				return false;
+			}
+		} else {
+			return false;
+		}
+	}
+
+	final public function valid(): bool
+	{
+		return isset($this->_subject, $this->_body)
+			and (! empty($this->_recipients) or ! empty($this->_cc) or ! empty($this->_bcc));
+	}
+}

--- a/classes/shgysk8zer0/requestitem.php
+++ b/classes/shgysk8zer0/requestitem.php
@@ -43,7 +43,7 @@ class RequestItem implements JSONSerializable
 		return $this->_qty;
 	}
 
-	final public functoin setQuantity(?int $val): void
+	final public function setQuantity(?int $val): void
 	{
 		$this->_qty = $val;
 	}
@@ -63,7 +63,7 @@ class RequestItem implements JSONSerializable
 		return $this->items;
 	}
 
-	final public function setItems(... object $val): void
+	final public function setItems(object... $val): void
 	{
 		$this->_items = $val;
 	}

--- a/consts.php
+++ b/consts.php
@@ -1,7 +1,10 @@
 <?php
 namespace Consts;
-
-const DEBUG             = true;
+define(__NAMESPACE__ . '\DEBUG', in_array(PHP_SAPI, ['cli', 'cli-server']));
+/* ======================== Site Specific Config ===================== */
+const SITE_NAME = 'KRV COVID-19 Healthy Shopping Resource';
+const SITE_URL  = 'https://needs.kernvalley.us';
+/* =================================================================== */
 const BASE              = __DIR__ . DIRECTORY_SEPARATOR;
 const DATA_DIR          = BASE . 'data' . DIRECTORY_SEPARATOR;
 const LOGS_DIR          = BASE . 'logs' . DIRECTORY_SEPARATOR;
@@ -66,6 +69,8 @@ define(__NAMESPACE__ . '\BASE_PATH',
 			), '/')
 	,'/') . '/'
 );
+
+define(__NAMESPACE__ . '\HAS_EMAIL_CREDS', file_exists(EMAIL_CREDS_FILE));
 
 define(__NAMESPACE__ . '\HMAC_KEY', file_get_contents(HMAC_FILE));
 

--- a/functions.php
+++ b/functions.php
@@ -25,6 +25,35 @@ function is_pwned(string $pwd): bool
 	}
 }
 
+function hmac_verify(string $data, string $hmac_key, $algo = 'sha2-256', string $key = 'hmac'):? object
+{
+	if ($obj = @json_decode(@base64_decode($data)) and isset($obj->{$key}) and is_string($obj->{$key})) {
+		$hmac = $obj->{$key};
+		unset($obj->{$key});
+
+		$hash = hash_hmac($algo, json_encode($obj), $hmac_key);
+		if (isset($hash) and hash_equals($hash, $hmac)) {
+			return $obj;
+		} else {
+			return null;
+		}
+	} else {
+		return null;
+	}
+}
+
+function hmac_sign_array(array $data, string $hmac_key, string $algo = 'sha3-256', string $key = 'hmac'):? string
+{
+	$json = json_encode($data);
+
+	if ($hmac = hash_hmac($algo, $json, $hmac_key)) {
+		$data[$key] = $hmac;
+		return base64_encode(json_encode($data));
+	} else {
+		return null;
+	}
+}
+
 function email(EmailCredentials $creds, Person $person, ?Person $from = null, string $subject, string $body): bool
 {
 	$mail = new PHPMailer(true);

--- a/passwordreset/index.php
+++ b/passwordreset/index.php
@@ -1,0 +1,143 @@
+<?php
+namespace PasswordReset;
+
+use \shgysk8zer0\PHPAPI\{PDO, API, Headers, HTTPException, URL};
+use \shgysk8zer0\PHPAPI\Abstracts\{HTTPStatusCodes as HTTP};
+use \shgysk8zer0\{User, EmailCredentials, Template, Email, Date, Person};
+use const \Consts\{HAS_EMAIL_CREDS, EMAIL_CREDS_FILE, HMAC_FILE, TEMPLATES_DIR, SITE_NAME, SITE_URL};
+use function \Functions\{hmac_sign_array, hmac_verify};
+const ALGO = 'sha3-256';
+const TYPE = 'password-recover';
+
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'autoloader.php';
+
+try {
+	$api = new API('*');
+
+	$api->on('GET', function(API $req): void
+	{
+		if ($req->get->has('token')) {
+			if ($data = hmac_verify($req->get->get('token', false), HMAC_KEY, ALGO, 'hmac')) {
+				Headers::contentType('application/json');
+
+				if (isset($data->date, $data->expires, $data->uuid, $data->type)) {
+					$data->expires = new Date($data->expires);
+					$data->date = new Date($data->date);
+					$now = new Date();
+
+					if ($data->type !== TYPE) {
+						throw new HTTPException('Invalid token', HTTP::UNAUTHORIZED);
+					} elseif ($now > $data->expires or $now < $data->date) {
+						throw new HTTPException('Token expired', HTTP::FORBIDDEN);
+					} elseif (! $person = Person::getFromIdentifier(PDO::load(), $data->uuid)) {
+						throw new HTTPException('User not found', HTTP::NOT_FOUND);
+					} else {
+						unset($person->address, $person->telephone);
+						echo json_encode($person);
+					}
+				} else {
+					throw new HTTPException('Token data invalid');
+				}
+			} else {
+				throw new HTTPException('Invalid or expired token', HTTP::NOT_FOUND);
+			}
+		} else {
+			throw new HTTPException('Missing token', HTTP::BAD_REQUEST);
+		}
+	});
+
+	$api->on('POST', function(API $req): void
+	{
+		if ($req->post->has('token', 'password')) {
+			if ($data = hmac_verify($req->post->get('token', false), HMAC_KEY, ALGO, 'hmac')) {
+				Headers::contentType('application/json');
+
+				if (isset($data->date, $data->expires, $data->uuid, $data->form)) {
+					$data->expires = new Date($data->expires);
+					$data->date = new Date($data->date);
+					$now = new Date();
+
+					if ($data->form !== FORM) {
+						throw new HTTPException('Invalid token', HTTP::UNAUTHORIZED);
+					} elseif ($now > $data->expires or $now < $data->date) {
+						throw new HTTPException('Token expired', HTTP::FORBIDDEN);
+					} elseif (! $person = Person::getFromIdentifier(PDO::load(), $data->uuid)) {
+						throw new HTTPException('User not found', HTTP::NOT_FOUND);
+					} elseif (! strlen($req->post->get('password', false)) > 8) {
+						throw new HTTPException('Password too short');
+					} elseif (User::resetPasswordforPerson(PDO::load(), $person, $req->post->get('password', false))) {
+						Headers::status(HTTP::NO_CONTENT);
+					} else {
+						throw new HTTPException('Error updating password', HTTP::INTERNAL_SERVER_ERROR);
+					}
+				} else {
+					throw new HTTPException('Token data invalid');
+				}
+			} else {
+				throw new HTTPException('Invalid or expired token', HTTP::NOT_FOUND);
+			}
+		} elseif ($req->post->has('email')) {
+			if (! filter_var($req->post->get('email', false), FILTER_VALIDATE_EMAIL)) {
+				throw new HTTPException('Invalid email address', HTTP::BAD_REQUEST);
+			} else {
+				ignore_user_abort(true);
+				set_time_limit(0);
+				ob_start();
+				Headers::status(HTTP::ACCEPTED);
+				Headers::set('Connection', 'close');
+				Headers::set('Content-Length', '0');
+				ob_end_flush();
+				ob_flush();
+				flush();
+
+				if ($user = User::getPersonFromEmail(PDO::load(), $req->post->get('email'))) {
+					if (HAS_EMAIL_CREDS) {
+						$url = new URL(SITE_URL);
+						$creds = new EmailCredentials(EMAIL_CREDS_FILE);
+						$now = new Date();
+						$expires = $now->modify('+6 hours');
+						$email = new Email($creds);
+
+						$hmac = hmac_sign_array([
+							'uuid'    => $user->getIdentifier(),
+							'date'    => $now->format(Date::W3C),
+							'expires' => $expires->format(Date::W3C),
+							'type'    => type,
+						], HMAC_KEY);
+
+						$template = new Template(TEMPLATES_DIR . 'password-reset.html');
+						$template->name = $user->getName();
+						$template->site = SITE_NAME;
+						$template->expiresDateTime = $expires->format(Date::W3C);
+						$template->expires = $expires->format('M jS h:i A');
+						$template->siteURL = $url;
+						$url->hash = "#password/reset/{$hmac}";
+						$template->resetLink = $url;
+						$email->addRecipients($user);
+						$email->setSubject(sprintf('Password Reset for %s', SITE_NAME));
+						$email->isHTML(true);
+						$email->setBody($template);
+						$email->send();
+					}
+				}
+			}
+		} else {
+			throw new HTTPException('Bad request', HTTP::BAD_REQUEST);
+		}
+	});
+
+	$api();
+} catch (HTTPException $e) {
+	Headers::status($e->getCode());
+	Headers::contentType('application/json');
+	echo json_encode($e);
+} catch (\Throwable $e) {
+	http_response_code(500);
+	header('Content-Type: application/json');
+	echo json_encode(['error' => [
+		'message' => $e->getMessage(),
+		'file'    => $e->getFile(),
+		'line'    => $e->getLine(),
+		'trace'   => $e->getTrace(),
+	]]);
+}

--- a/templates/password-reset.html
+++ b/templates/password-reset.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+	<head>
+		<meta charset="utf-8" />
+	</head>
+	<body>
+		<p><b>A password reset has been requested for <span>%NAME%</span> on <a href="%SITEURL%">%SITE%</a></b>.</p>
+		<p>If you requested this, click <a href="%RESETLINK%">here</a> to enter a new password. The link expires on <time datetime="%EXPIRESDATETIME%">%EXPIRES%</time>.</p>
+		<p>If you did not request this, ignore this email.</p>
+	</body>
+</html>


### PR DESCRIPTION
- Endpoint to initiate request
- Custom token with validation
- Functions to generate & verify tokens
- Tokens now have types to set scope / usage
- Add site data to constants (front-end stuff)
- Add password reset email template
- Fix `shgysk8zer0\Abstracts\Schema::__unset()` return type hinting
- Add email class using PHPMailer
- Add PHP linting as GitHub Action / Workflow